### PR TITLE
fix(regex): username validator now compliant with below rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "medullah-web"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "medullah-web"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 repository = "https://github.com/spiralover/medullah-web"
 

--- a/src/helpers/string.rs
+++ b/src/helpers/string.rs
@@ -15,6 +15,6 @@ pub fn password_verify(hash: &str, password: &str) -> bool {
 
 #[cfg(feature = "feat-regex")]
 pub fn is_username_valid(name: String) -> Box<fancy_regex::Result<bool>> {
-    let regex = fancy_regex::Regex::new(r"^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$").unwrap();
+    let regex = fancy_regex::Regex::new(r"^[a-z][a-z\d\.]{0,37}$").unwrap();
     Box::new(regex.is_match(name.as_str()))
 }


### PR DESCRIPTION
- must start with a-z
- can follow by number
- don't allow special chars
- but allow dot(.)