### PR TITLE
* refactor(rabbitmq): recreate closed channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Medullah Changelog
 medullah-web changelog file 
 
+## 0.19.0 (2024-09-07)
+* refactor(rabbitmq): recreate closed channel
+* feat(rabbitmq): global state is now wrapped around Arc<Mutex<>>
+* fix(rabbitmq): execute_handler_asynchronously not being set correctly
+* refactor(rabbitmq): renamed "set_nack_on_failure" to "nack_on_failure"
+* feat(rabbitmq): add "requeue_on_failure" method
+
 ## 0.18.2 (2024-09-05)
 * feat(rabbitmq): use tag to provide more context in error log
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "medullah-web"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "medullah-web"
-version = "0.18.2"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 description = "Micro-Framework Base on Ntex"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -43,7 +43,7 @@ pub struct MedullahState {
     #[cfg(feature = "feat-rabbitmq")]
     pub rabbitmq_pool: deadpool_lapin::Pool,
     #[cfg(feature = "feat-rabbitmq")]
-    pub rabbitmq: Arc<RabbitMQ>,
+    pub rabbitmq: Arc<tokio::sync::Mutex<RabbitMQ>>,
     #[cfg(feature = "feat-database")]
     pub(crate) database: crate::database::DBPool,
 
@@ -103,8 +103,8 @@ impl MedullahState {
     }
 
     #[cfg(feature = "feat-rabbitmq")]
-    pub fn rabbitmq(&self) -> Arc<RabbitMQ> {
-        self.rabbitmq.clone()
+    pub fn rabbitmq(&self) -> Arc<tokio::sync::Mutex<RabbitMQ>> {
+        Arc::clone(&self.rabbitmq)
     }
 
     pub fn title(&self, text: &str) -> String {

--- a/src/helpers/once_lock.rs
+++ b/src/helpers/once_lock.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, OnceLock};
 use diesel::r2d2::ConnectionManager;
 #[cfg(feature = "feat-database")]
 use diesel::PgConnection;
-
 use crate::app_state::{AppHelpers, MedullahState};
 #[cfg(feature = "feat-database")]
 use crate::database::DatabaseConnectionHelper;
@@ -57,7 +56,7 @@ pub trait OnceLockHelper<'a> {
     }
 
     #[cfg(feature = "feat-rabbitmq")]
-    fn rabbitmq(&self) -> Arc<crate::rabbitmq::RabbitMQ> {
+    fn rabbitmq(&self) -> Arc<tokio::sync::Mutex<crate::prelude::RabbitMQ>> {
         Arc::clone(&self.app().rabbitmq)
     }
 


### PR DESCRIPTION
* feat(rabbitmq): global state is now wrapped around Arc<Mutex<>>
* fix(rabbitmq): execute_handler_asynchronously not being set correctly
* refactor(rabbitmq): renamed "set_nack_on_failure" to "nack_on_failure"
* feat(rabbitmq): add "requeue_on_failure" method